### PR TITLE
Fixing resolution issues

### DIFF
--- a/Directory.build.props
+++ b/Directory.build.props
@@ -48,15 +48,15 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
 
-  <ItemGroup Condition=" $(IsPackable) ">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  <ItemGroup Condition=" $(IsPackable) == 'true' ">
+    <PackageReference Condition="$(BUILD_ARTIFACTSTAGINGDIRECTORY) != ''" Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <None Include="$(MSBuildThisFileDirectory)prism-logo.png"
           Visible="False"
           Pack="True"
           PackagePath="" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' And '$(IsPackable)' ">
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' And '$(IsPackable)' == 'true' ">
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/sample/PrismSample.Android/Properties/AndroidManifest.xml
+++ b/sample/PrismSample.Android/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.prismlibrary.prismsample">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.prismlibrary.prismextensions">
     <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="28" />
-    <application android:label="Prism Sample"></application>
+    <application android:label="Prism Extended"></application>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>

--- a/sample/PrismSample.iOS/Info.plist
+++ b/sample/PrismSample.iOS/Info.plist
@@ -23,9 +23,9 @@
 	<key>MinimumOSVersion</key>
 	<string>10.0</string>
 	<key>CFBundleDisplayName</key>
-	<string>Prism Sample</string>
+	<string>Prism Extended</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.prismlibrary.PrismSample</string>
+	<string>com.prismlibrary.prismextensions</string>
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
 	<key>UILaunchStoryboardName</key>

--- a/src/Prism.DryIoc.Extensions/Prism.DryIoc.Extensions.csproj
+++ b/src/Prism.DryIoc.Extensions/Prism.DryIoc.Extensions.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DryIoc.dll" Version="4.1.0" />
+    <PackageReference Include="DryIoc.dll" Version="4.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Prism.Forms.Extended/Ioc/IContainerRegistryExtensions.cs
+++ b/src/Prism.Forms.Extended/Ioc/IContainerRegistryExtensions.cs
@@ -29,7 +29,8 @@ namespace Prism.Ioc
             containerRegistry.RegisterSingletonOnce<IModuleManager, ModuleManager>();
             containerRegistry.RegisterSingletonOnce<IModuleInitializer, ModuleInitializer>();
             containerRegistry.RegisterSingletonOnce<IDialogService, DialogService>();
-            containerRegistry.RegisterOnce<INavigationService, ErrorReportingNavigationService>(PrismApplicationBase.NavigationServiceName);
+            containerRegistry.Register<INavigationService, ErrorReportingNavigationService>(PrismApplicationBase.NavigationServiceName);
+            containerRegistry.Register<INavigationService, ErrorReportingNavigationService>();
         }
 
         public static void RegisterPrismCoreServices(this IServiceCollection services)

--- a/src/Prism.Forms.Extended/Prism.Forms.Extended.csproj
+++ b/src/Prism.Forms.Extended/Prism.Forms.Extended.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;MonoAndroid80;MonoAndroid81;MonoAndroid90;Xamarin.iOS10</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;MonoAndroid90;Xamarin.iOS10</TargetFrameworks>
     <Description>Provides an extended PrismApplication with additional helpers. This can assist with capturing errors and debugging. Additional helpers exist to provide better use of Platform Specifics and styling.</Description>
     <PackageTags>prism xamarin.forms forms extensions</PackageTags>
   </PropertyGroup>

--- a/tests/Prism.Container.Extensions.Shared.Tests/Tests/CommonAspNetServiceTests.cs
+++ b/tests/Prism.Container.Extensions.Shared.Tests/Tests/CommonAspNetServiceTests.cs
@@ -36,6 +36,19 @@ namespace Prism.Container.Extensions.Shared.Tests
         }
 
         [Fact]
+        public void IHttpClientFactoryIsResolvable()
+        {
+            ConfigureServices();
+            IHttpClientFactory service = null;
+            PrismContainerExtension.Current.CreateScope();
+            var ex = Record.Exception(() => service = PrismContainerExtension.Current.Resolve<IHttpClientFactory>());
+
+            Assert.Null(ex);
+            Assert.NotNull(service);
+            Assert.IsAssignableFrom<IHttpClientFactory>(service);
+        }
+
+        [Fact]
         public void DbContextResolveableWithoutScope()
         {
             ConfigureServices();

--- a/tests/Prism.Forms.Extended.Mocks/Tests/PrismApplicationTests.cs
+++ b/tests/Prism.Forms.Extended.Mocks/Tests/PrismApplicationTests.cs
@@ -14,6 +14,7 @@ using AndroidTabbedPage = Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Ta
 using iOSPage = Xamarin.Forms.PlatformConfiguration.iOSSpecific.Page;
 using iOSNavPage = Xamarin.Forms.PlatformConfiguration.iOSSpecific.NavigationPage;
 using Prism.Forms.Extended.Mocks.Views;
+using Prism.Navigation;
 #if DRYIOC
 using Prism.DryIoc;
 #elif UNITY
@@ -115,6 +116,18 @@ namespace Prism.Forms.Extended.Tests
             Assert.IsType<ViewB>(app.MainPage);
 
             Assert.False(iOSPage.GetUseSafeArea(app.MainPage));
+        }
+
+        [Fact]
+        public void ErrorReportingNavigationServiceIsRegistered()
+        {
+            var app = CreateApp();
+            INavigationService navService = null;
+            var ex = Record.Exception(() => navService = app.Container.Resolve<INavigationService>(PrismApplicationBase.NavigationServiceName));
+
+            Assert.Null(ex);
+            Assert.NotNull(navService);
+            Assert.IsType<ErrorReportingNavigationService>(navService);
         }
 
         private AppMock CreateApp(string runtimePlatform = "Test")


### PR DESCRIPTION
Adds tests and known bugs from latest release

- INavigationService does not resolve in Prism.DryIoc.Extensions. This was due to an unknown change in DryIoc 4.1.0. This has been rolled back until the root issue can be identified.
- Issue #80 unable to resolve IHttpClientFactory due to missing registration for IServiceScopeFactory