### PR TITLE
[Shiny] Resolve<IEnumerable<T>>() or ResolveAll<T>()

### DIFF
--- a/Prism.Container.Extensions.sln
+++ b/Prism.Container.Extensions.sln
@@ -69,7 +69,13 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PrismSample.UWP", "sample\P
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		tests\Prism.Container.Extensions.Shared.Tests\Prism.Container.Extensions.Shared.Tests.projitems*{24ced393-e72c-4a67-b367-9d7ac5ca6e00}*SharedItemsImports = 5
+		tests\Prism.Forms.Extended.Mocks\Prism.Forms.Extended.Mocks.projitems*{407f4e72-cc87-4a58-841b-b75cd914f8b1}*SharedItemsImports = 5
+		tests\Prism.Container.Extensions.Shared.Tests\Prism.Container.Extensions.Shared.Tests.projitems*{626759d0-9075-434f-a239-e3c8ac180c44}*SharedItemsImports = 5
+		tests\Prism.Forms.Extended.Mocks\Prism.Forms.Extended.Mocks.projitems*{9d2c6e7d-4c6e-4606-a3fa-43b18ed56f32}*SharedItemsImports = 5
 		tests\Prism.Container.Extensions.Shared.Tests\Prism.Container.Extensions.Shared.Tests.projitems*{a000e151-d04b-4f18-92a9-173e60975fbc}*SharedItemsImports = 13
+		tests\Prism.Forms.Extended.Mocks\Prism.Forms.Extended.Mocks.projitems*{a1664ca9-907a-4af7-9100-c69ccd26900e}*SharedItemsImports = 5
+		tests\Prism.Container.Extensions.Shared.Tests\Prism.Container.Extensions.Shared.Tests.projitems*{d1367051-9f5c-4f7b-9135-6095541c47b2}*SharedItemsImports = 5
 		tests\Prism.Forms.Extended.Mocks\Prism.Forms.Extended.Mocks.projitems*{e13e43d5-6a03-401c-b7e6-298e829e5a2f}*SharedItemsImports = 13
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Prism.DryIoc.Extensions/PrismContainerExtension.cs
+++ b/src/Prism.DryIoc.Extensions/PrismContainerExtension.cs
@@ -155,7 +155,8 @@ namespace Prism.DryIoc
 
         public bool IsRegistered(Type type)
         {
-            return Instance.IsRegistered(type);
+            return Instance.IsRegistered(type) ||
+                Instance.IsRegistered(type, factoryType: FactoryType.Wrapper);
         }
 
         public bool IsRegistered(Type type, string name)

--- a/tests/Prism.DryIoc.Extensions.Tests/ContainerTests.cs
+++ b/tests/Prism.DryIoc.Extensions.Tests/ContainerTests.cs
@@ -147,6 +147,13 @@ namespace Prism.DryIoc.Extensions.Tests
             Assert.IsType<Foo>(foo);
 
             Assert.Same(foo, c.Resolve<IFoo>());
+
+            IEnumerable<IFoo> foos = null;
+            ex = Record.Exception(() => foos = c.Resolve<IEnumerable<IFoo>>());
+
+            Assert.Null(ex);
+            Assert.NotNull(foos);
+            Assert.Equal(new[] { foo }, foos);
         }
 
         [Fact]

--- a/tests/Shiny.Prism.Tests/Mocks/Delegates/MockPushDelegate.cs
+++ b/tests/Shiny.Prism.Tests/Mocks/Delegates/MockPushDelegate.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Shiny.Push;
+
+namespace Shiny.Prism.Mocks.Delegates
+{
+    public class MockPushDelegate : IPushDelegate
+    {
+        public Task OnEntry(PushEntryArgs args)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task OnReceived(IDictionary<string, string> data)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task OnTokenChanged(string token)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/tests/Shiny.Prism.Tests/Mocks/ShinyPrismTestHost.cs
+++ b/tests/Shiny.Prism.Tests/Mocks/ShinyPrismTestHost.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using Microsoft.Extensions.DependencyInjection;
 using Shiny.IO;
 using Shiny.Jobs;
@@ -18,7 +16,8 @@ namespace Shiny.Prism.Mocks
 {
     class ShinyPrismTestHost : ShinyHost
     {
-        public static void Init(ITestOutputHelper testOutputHelper) => Init(new MockStartup(testOutputHelper));
+        public static void Init(ITestOutputHelper testOutputHelper, Action<IServiceCollection> platformBuild = null)
+            => Init(new MockStartup(testOutputHelper), platformBuild);
 
         public static void Init(IShinyStartup startup = null, Action<IServiceCollection> platformBuild = null)
         {

--- a/tests/Shiny.Prism.Tests/Tests/PrismStartupTests.cs
+++ b/tests/Shiny.Prism.Tests/Tests/PrismStartupTests.cs
@@ -1,11 +1,16 @@
 using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
 using Prism.DryIoc;
 using Prism.Ioc;
+using Shiny;
 using Shiny.IO;
 using Shiny.Jobs;
 using Shiny.Net;
 using Shiny.Power;
 using Shiny.Prism.Mocks;
+using Shiny.Prism.Mocks.Delegates;
+using Shiny.Push;
 using Shiny.Settings;
 using Shiny.Testing;
 using Shiny.Testing.Jobs;
@@ -51,6 +56,26 @@ namespace Shiny.Prism.Tests
             var fromShiny = ShinyHost.Container.GetService(serviceType);
             Assert.IsType(implementingType, fromShiny);
             Assert.Same(fromShiny, PrismContainerExtension.Current.Resolve(serviceType));
+        }
+
+        [Fact]
+        public void CanResolveAll()
+        {
+            ShinyPrismTestHost.Init(_testOutputHelper, services =>
+            {
+                services.AddSingleton<IPushDelegate, MockPushDelegate>();
+            });
+
+            Assert.True(PrismContainerExtension.Current.IsRegistered(typeof(IPushDelegate)));
+
+            var fromShiny = ShinyHost.Resolve<IPushDelegate>();
+            Assert.IsType<MockPushDelegate>(fromShiny);
+            Assert.Same(fromShiny, PrismContainerExtension.Current.Resolve(typeof(IPushDelegate)));
+            Assert.Same(fromShiny, ShinyHost.Container.Resolve<IPushDelegate>());
+
+            Assert.Equal(new[] { fromShiny }, ShinyHost.Container.Resolve<IEnumerable<IPushDelegate>>());
+            // Assert.Equal(new[] { fromShiny }, ShinyHost.Container.ResolveAll<IPushDelegate>()); // TODO: exists in Shiny 1.2
+            Assert.Equal(new[] { fromShiny }, ShinyHost.ResolveAll<IPushDelegate>());
         }
 
         [Fact]

--- a/tests/Shiny.Prism.Tests/Tests/PrismStartupTests.cs
+++ b/tests/Shiny.Prism.Tests/Tests/PrismStartupTests.cs
@@ -73,8 +73,9 @@ namespace Shiny.Prism.Tests
             Assert.Same(fromShiny, PrismContainerExtension.Current.Resolve(typeof(IPushDelegate)));
             Assert.Same(fromShiny, ShinyHost.Container.Resolve<IPushDelegate>());
 
+            Assert.Equal(new[] { fromShiny }, PrismContainerExtension.Current.Resolve<IEnumerable<IPushDelegate>>());
+            Assert.Equal(new[] { fromShiny }, ShinyHost.Container.GetServices<IPushDelegate>());
             Assert.Equal(new[] { fromShiny }, ShinyHost.Container.Resolve<IEnumerable<IPushDelegate>>());
-            // Assert.Equal(new[] { fromShiny }, ShinyHost.Container.ResolveAll<IPushDelegate>()); // TODO: exists in Shiny 1.2
             Assert.Equal(new[] { fromShiny }, ShinyHost.ResolveAll<IPushDelegate>());
         }
 

--- a/tests/Shiny.Prism.Tests/Tests/PrismStartupTests.cs
+++ b/tests/Shiny.Prism.Tests/Tests/PrismStartupTests.cs
@@ -80,6 +80,21 @@ namespace Shiny.Prism.Tests
         }
 
         [Fact]
+        public void CanResolveAllWithoutRegistration()
+        {
+            ShinyPrismTestHost.Init(_testOutputHelper);
+
+            Assert.False(PrismContainerExtension.Current.IsRegistered(typeof(IPushDelegate)));
+
+            Assert.Null(ShinyHost.Resolve<IPushDelegate>());
+
+            Assert.Empty(PrismContainerExtension.Current.Resolve<IEnumerable<IPushDelegate>>());
+            Assert.Empty(ShinyHost.Container.GetServices<IPushDelegate>());
+            Assert.Empty(ShinyHost.Container.Resolve<IEnumerable<IPushDelegate>>());
+            Assert.Empty(ShinyHost.ResolveAll<IPushDelegate>());
+        }
+
+        [Fact]
         public void PrismStartupLocatesContainerExtension()
         {
             var ex = Record.Exception(() => ShinyPrismTestHost.Init(new MockStartup(_testOutputHelper, false)));


### PR DESCRIPTION
I initially reported this as https://github.com/shinyorg/shiny/issues/359, but @aritchie added some tests that suggest the issue is specific to Shiny.Prism. Specifically, `Resolve<IEnumerable<T>>()` is returning `null` instead of the expected collection. (I opted not to upgrade to Shiny 1.2, which introduces an equivalent `ResolveAll<T>()` extension.)

It looks like DryIoc can `Resolve<IEnumerable<T>>()` as expected, so the issue seems specific to how Shiny is being set up. Any ideas, @dansiegel?

**Note:** PR is branched from v7.2.0.1054 rather than red `master`.