### PR TITLE
Registration Fixes

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,17 +28,17 @@ theme:
 # Social
 extra:
   social:
-    - type: globe
+    - icon: fontawesome/brands/html5
       link: https://dansiegel.net
-    - type: github
+    - icon: fontawesome/brands/github
       link: https://github.com/dansiegel
-    - type: twitch
+    - icon: fontawesome/brands/twitch
       link: https://twitch.tv/dansiegel
-    - type: twitter
+    - icon: fontawesome/brands/twitter
       link: https://twitter.com/DanJSiegel
-    - type: youtube
+    - icon: fontawesome/brands/youtube
       link: https://www.youtube.com/DanSiegel
-    - type: linkedin
+    - icon: fontawesome/brands/linkedin
       link: https://linkedin.com/in/DanSiegel
 
 # Extensions

--- a/sample/PrismSample.Android/PrismSample.Android.csproj
+++ b/sample/PrismSample.Android/PrismSample.Android.csproj
@@ -53,7 +53,7 @@
     <Reference Include="System.Numerics.Vectors" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.6.0.967" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1269" />
     <PackageReference Include="Xamarin.Android.Support.Core.Utils" Version="28.0.0.3" />
   </ItemGroup>
   <ItemGroup>
@@ -95,6 +95,10 @@
     <ProjectReference Include="..\..\src\Prism.Container.Extensions\Prism.Container.Extensions.csproj">
       <Project>{940ca2d8-b9a8-499a-9ed3-ecee9758073f}</Project>
       <Name>Prism.Container.Extensions</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Prism.DryIoc.Extensions\Prism.DryIoc.Extensions.csproj">
+      <Project>{3a82a96a-f3fc-4244-87c3-28706494f614}</Project>
+      <Name>Prism.DryIoc.Extensions</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\src\Prism.Forms.Extended\Prism.Forms.Extended.csproj">
       <Project>{771a0fd7-7877-4ab7-8528-7fb07054393d}</Project>

--- a/sample/PrismSample.UWP/PrismSample.UWP.csproj
+++ b/sample/PrismSample.UWP/PrismSample.UWP.csproj
@@ -143,7 +143,7 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.6.0.967" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1269" />
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.10" />
   </ItemGroup>
   <ItemGroup>

--- a/sample/PrismSample.iOS/PrismSample.iOS.csproj
+++ b/sample/PrismSample.iOS/PrismSample.iOS.csproj
@@ -125,13 +125,17 @@
     <Reference Include="System.Numerics.Vectors" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.6.0.967" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1269" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>
     <ProjectReference Include="..\..\src\Prism.Container.Extensions\Prism.Container.Extensions.csproj">
       <Project>{940ca2d8-b9a8-499a-9ed3-ecee9758073f}</Project>
       <Name>Prism.Container.Extensions</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Prism.DryIoc.Extensions\Prism.DryIoc.Extensions.csproj">
+      <Project>{3a82a96a-f3fc-4244-87c3-28706494f614}</Project>
+      <Name>Prism.DryIoc.Extensions</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\src\Prism.Forms.Extended\Prism.Forms.Extended.csproj">
       <Project>{771a0fd7-7877-4ab7-8528-7fb07054393d}</Project>

--- a/sample/PrismSample/PrismSample.csproj
+++ b/sample/PrismSample/PrismSample.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Humanizer.Core" Version="2.8.26" />
-    <PackageReference Include="Xamarin.Forms" Version="4.6.0.967" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1269" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Prism.DryIoc.Extensions/Prism.DryIoc.Extensions.csproj
+++ b/src/Prism.DryIoc.Extensions/Prism.DryIoc.Extensions.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DryIoc.dll" Version="4.2.1" />
+    <PackageReference Include="DryIoc.dll" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Prism.Microsoft.DependencyInjection.Extensions/MicrsoftDependencyInjectionExtensions.cs
+++ b/src/Prism.Microsoft.DependencyInjection.Extensions/MicrsoftDependencyInjectionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.DependencyInjection;
 using Prism.Ioc;
@@ -18,6 +19,29 @@ namespace Prism.Microsoft.DependencyInjection
             }
 
             throw new NotImplementedException("IContainerRegistry must be implmented from the concrete type PrismContainerExtension");
+        }
+
+        internal static object GetOrConstructService(this IServiceProvider provider, Type type, params (Type Type, object Instance)[] parameters)
+        {
+            var instance = provider.GetService(type);
+            if (instance is null && !type.IsInterface && !type.IsAbstract)
+            {
+                var ctor = type.GetConstructors().OrderByDescending(x => x.GetParameters().Length).FirstOrDefault();
+                if (ctor is null)
+                    throw new NullReferenceException($"Could not locate a public constructor for {type.FullName}");
+
+                var ctorParameters = ctor.GetParameters();
+                var args = ctor.GetParameters().Select(x =>
+                {
+                    object arg = parameters.FirstOrDefault(p => x.ParameterType.IsAssignableFrom(p.Instance.GetType())).Instance;
+                    if (arg != null)
+                        return arg;
+
+                    return provider.GetService(x.ParameterType);
+                });
+                return ctor.Invoke(args.ToArray());
+            }
+            return instance;
         }
     }
 }

--- a/src/Prism.Microsoft.DependencyInjection.Extensions/NamedServiceRegistry.cs
+++ b/src/Prism.Microsoft.DependencyInjection.Extensions/NamedServiceRegistry.cs
@@ -53,6 +53,11 @@ namespace Prism.Microsoft.DependencyInjection
             return registry?.GetService(serviceProvider);
         }
 
+        public Type GetRegistrationType(string key)
+        {
+            return Services.FirstOrDefault(x => x.Name.Equals(key, StringComparison.OrdinalIgnoreCase) || x.ImplementationType.Name.Equals(key, StringComparison.OrdinalIgnoreCase))?.ImplementationType;
+        }
+
         private void CheckDuplicate(string name, Type serviceType)
         {
             var registry = GetServiceRegistry(name, serviceType);
@@ -73,7 +78,7 @@ namespace Prism.Microsoft.DependencyInjection
             public Type ImplementationType { get; set; }
 
             public virtual object GetService(IServiceProvider serviceProvider) =>
-                serviceProvider.GetService(ImplementationType);
+                serviceProvider.GetOrConstructService(ImplementationType);
         }
 
         class NamedSingletonService : NamedService
@@ -84,7 +89,7 @@ namespace Prism.Microsoft.DependencyInjection
             {
                 if(Instance is null)
                 {
-                    Instance = serviceProvider.GetService(ImplementationType);
+                    Instance = serviceProvider.GetOrConstructService(ImplementationType);
                 }
 
                 return Instance;

--- a/src/Prism.Microsoft.DependencyInjection.Extensions/PrismContainerExtension.cs
+++ b/src/Prism.Microsoft.DependencyInjection.Extensions/PrismContainerExtension.cs
@@ -123,8 +123,16 @@ namespace Prism.Microsoft.DependencyInjection
 
         public object Resolve(Type type, params (Type Type, object Instance)[] parameters)
         {
-            var provider = parameters.Length > 0 ? GetChildProvider(parameters) : Instance;
-            return provider.GetService(type) ?? throw NullResolutionException(type);
+            try
+            {
+                var provider = parameters.Length > 0 ? GetChildProvider(parameters) : Instance;
+
+                return provider.GetOrConstructService(type, parameters) ?? throw NullResolutionException(type);
+            }
+            catch (Exception ex)
+            {
+                throw new ContainerResolutionException(type, ex);
+            }
         }
 
         public object Resolve(Type type, string name, params (Type Type, object Instance)[] parameters)

--- a/tests/Prism.Container.Extensions.Shared.Tests/Mocks/GenericService.cs
+++ b/tests/Prism.Container.Extensions.Shared.Tests/Mocks/GenericService.cs
@@ -9,6 +9,11 @@ namespace Prism.Container.Extensions.Shared.Mocks
         public string Name { get; set; }
     }
 
+    public class AltGenericService : IGenericService
+    {
+        public string Name { get; set; }
+    }
+
     public interface IGenericService
     {
         string Name { get; }

--- a/tests/Prism.DryIoc.Extensions.Tests/ContainerTests.cs
+++ b/tests/Prism.DryIoc.Extensions.Tests/ContainerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using Prism.Container.Extensions.Shared.Mocks;
 using Prism.Container.Extensions.Shared.Tests;
 using Prism.Container.Extensions.Tests.Mocks;
@@ -412,6 +413,34 @@ namespace Prism.DryIoc.Extensions.Tests
 
             Assert.Same(genA, c.Resolve<IGenericService>("genA"));
             Assert.Same(genB, c.Resolve<IGenericService>("genB"));
+        }
+
+        [Fact]
+        public void ResolveTakesLastIn()
+        {
+            var c = CreateContainer();
+            c.Register<IGenericService, GenericService>();
+            c.Register<IGenericService, AltGenericService>();
+
+            Assert.IsType<AltGenericService>(c.Resolve<IGenericService>());
+        }
+
+        [Fact]
+        public void ResolveEnumerableResolvesAll()
+        {
+            var c = CreateContainer();
+            c.Register<IGenericService, GenericService>();
+            c.Register<IGenericService, AltGenericService>();
+
+            IEnumerable<IGenericService> all = null;
+            var ex = Record.Exception(() => all = c.Resolve<IEnumerable<IGenericService>>());
+
+            Assert.Null(ex);
+            Assert.NotNull(all);
+            Assert.NotEmpty(all);
+            Assert.Equal(2, all.Count());
+            Assert.Contains(all, x => x is GenericService);
+            Assert.Contains(all, x => x is AltGenericService);
         }
 
         public static IFoo FooFactory() => new Foo { Message = "expected" };

--- a/tests/Prism.DryIoc.Extensions.Tests/Prism.DryIoc.Extensions.Tests.csproj
+++ b/tests/Prism.DryIoc.Extensions.Tests/Prism.DryIoc.Extensions.Tests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Prism.DryIoc.Forms.Extended.Tests/Prism.DryIoc.Forms.Extended.Tests.csproj
+++ b/tests/Prism.DryIoc.Forms.Extended.Tests/Prism.DryIoc.Forms.Extended.Tests.csproj
@@ -9,10 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="Xamarin.Forms" Version="4.6.0.967" />
-    <PackageReference Include="Xamarin.Forms.Mocks" Version="4.6.0.1" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1269" />
+    <PackageReference Include="Xamarin.Forms.Mocks" Version="4.7.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Prism.Forms.Extended.Mocks/Mocks/ViewModels/ViewAViewModel.cs
+++ b/tests/Prism.Forms.Extended.Mocks/Mocks/ViewModels/ViewAViewModel.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Prism.Forms.Extended.Mocks.Views;
+using Prism.Navigation;
+
+namespace Prism.Forms.Extended.Mocks.ViewModels
+{
+    public class ViewAViewModel
+    {
+        public INavigationService NavigationService { get; }
+
+        public ViewAViewModel(INavigationService navigationService)
+        {
+            NavigationService = navigationService;
+        }
+    }
+}

--- a/tests/Prism.Forms.Extended.Mocks/Mocks/ViewModels/ViewBViewModel.cs
+++ b/tests/Prism.Forms.Extended.Mocks/Mocks/ViewModels/ViewBViewModel.cs
@@ -1,0 +1,14 @@
+﻿using Prism.Navigation;
+
+namespace Prism.Forms.Extended.Mocks.ViewModels
+{
+    public class ViewBViewModel
+    {
+        public INavigationService NavigationService { get; }
+
+        public ViewBViewModel(INavigationService navigationService)
+        {
+            NavigationService = navigationService;
+        }
+    }
+}

--- a/tests/Prism.Forms.Extended.Mocks/Mocks/ViewModels/ViewCViewModel.cs
+++ b/tests/Prism.Forms.Extended.Mocks/Mocks/ViewModels/ViewCViewModel.cs
@@ -1,0 +1,14 @@
+﻿using Prism.Navigation;
+
+namespace Prism.Forms.Extended.Mocks.ViewModels
+{
+    public class ViewCViewModel
+    {
+        public INavigationService NavigationService { get; }
+
+        public ViewCViewModel(INavigationService navigationService)
+        {
+            NavigationService = navigationService;
+        }
+    }
+}

--- a/tests/Prism.Forms.Extended.Mocks/Mocks/ViewModels/ViewDViewModel.cs
+++ b/tests/Prism.Forms.Extended.Mocks/Mocks/ViewModels/ViewDViewModel.cs
@@ -1,0 +1,14 @@
+﻿using Prism.Navigation;
+
+namespace Prism.Forms.Extended.Mocks.ViewModels
+{
+    public class ViewDViewModel
+    {
+        public INavigationService NavigationService { get; }
+
+        public ViewDViewModel(INavigationService navigationService)
+        {
+            NavigationService = navigationService;
+        }
+    }
+}

--- a/tests/Prism.Forms.Extended.Mocks/Prism.Forms.Extended.Mocks.projitems
+++ b/tests/Prism.Forms.Extended.Mocks/Prism.Forms.Extended.Mocks.projitems
@@ -14,6 +14,10 @@
       <DependentUpon>AppMock.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Mocks\Navigation\MockNavigationService.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Mocks\ViewModels\ViewAViewModel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Mocks\ViewModels\ViewBViewModel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Mocks\ViewModels\ViewCViewModel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Mocks\ViewModels\ViewDViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Mocks\Views\ViewD.xaml.cs">
       <DependentUpon>ViewD.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/tests/Prism.Microsoft.DependencyInjection.Extensions.Forms.Tests/Prism.Microsoft.DependencyInjection.Forms.Extended.Tests.csproj
+++ b/tests/Prism.Microsoft.DependencyInjection.Extensions.Forms.Tests/Prism.Microsoft.DependencyInjection.Forms.Extended.Tests.csproj
@@ -8,10 +8,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="Xamarin.Forms" Version="4.6.0.967" />
-    <PackageReference Include="Xamarin.Forms.Mocks" Version="4.6.0.1" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1269" />
+    <PackageReference Include="Xamarin.Forms.Mocks" Version="4.7.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Prism.Microsoft.DependencyInjection.Extensions.Tests/ContainerTests.cs
+++ b/tests/Prism.Microsoft.DependencyInjection.Extensions.Tests/ContainerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Prism.Container.Extensions.Shared.Mocks;
 using Prism.Container.Extensions.Shared.Tests;
@@ -514,6 +515,34 @@ namespace Prism.Microsoft.DependencyInjection.Extensions.Tests
                 Assert.Same(genA, c.Resolve<IGenericService>("genA"));
                 Assert.Same(genB, c.Resolve<IGenericService>("genB"));
             }
+        }
+
+        [Fact]
+        public void ResolveTakesLastIn()
+        {
+            var c = CreateContainer();
+            c.Register<IGenericService, GenericService>();
+            c.Register<IGenericService, AltGenericService>();
+
+            Assert.IsType<AltGenericService>(c.Resolve<IGenericService>());
+        }
+
+        [Fact]
+        public void ResolveEnumerableResolvesAll()
+        {
+            var c = CreateContainer();
+            c.Register<IGenericService, GenericService>();
+            c.Register<IGenericService, AltGenericService>();
+
+            IEnumerable<IGenericService> all = null;
+            var ex = Record.Exception(() => all = c.Resolve<IEnumerable<IGenericService>>());
+
+            Assert.Null(ex);
+            Assert.NotNull(all);
+            Assert.NotEmpty(all);
+            Assert.Equal(2, all.Count());
+            Assert.Contains(all, x => x is GenericService);
+            Assert.Contains(all, x => x is AltGenericService);
         }
 
         public static IFoo FooFactory() => new Foo { Message = "expected" };

--- a/tests/Prism.Microsoft.DependencyInjection.Extensions.Tests/Prism.Microsoft.DependencyInjection.Extensions.Tests.csproj
+++ b/tests/Prism.Microsoft.DependencyInjection.Extensions.Tests/Prism.Microsoft.DependencyInjection.Extensions.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Prism.Unity.Extensions.Tests/ContainerTests.cs
+++ b/tests/Prism.Unity.Extensions.Tests/ContainerTests.cs
@@ -1,13 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using Unity;
-using Prism.Container.Extensions.Tests.Mocks;
-using Prism.Ioc;
-using Xunit;
-using Xunit.Abstractions;
+using System.Linq;
 using Prism.Container.Extensions.Shared.Mocks;
 using Prism.Container.Extensions.Shared.Tests;
+using Prism.Container.Extensions.Tests.Mocks;
+using Prism.Ioc;
+using Unity;
+using Xunit;
+using Xunit.Abstractions;
 
 namespace Prism.Unity.Extensions.Tests
 {
@@ -499,6 +500,34 @@ namespace Prism.Unity.Extensions.Tests
                 Assert.Same(genA, c.Resolve<IGenericService>("genA"));
                 Assert.Same(genB, c.Resolve<IGenericService>("genB"));
             }
+        }
+
+        [Fact]
+        public void ResolveTakesLastIn()
+        {
+            var c = CreateContainer();
+            c.Register<IGenericService, GenericService>();
+            c.Register<IGenericService, AltGenericService>();
+
+            Assert.IsType<AltGenericService>(c.Resolve<IGenericService>());
+        }
+
+        [Fact(Skip = "Not Supported on Unity")]
+        public void ResolveEnumerableResolvesAll()
+        {
+            var c = CreateContainer();
+            c.Register<IGenericService, GenericService>();
+            c.Register<IGenericService, AltGenericService>();
+
+            IEnumerable<IGenericService> all = null;
+            var ex = Record.Exception(() => all = c.Resolve<IEnumerable<IGenericService>>());
+
+            Assert.Null(ex);
+            Assert.NotNull(all);
+            Assert.NotEmpty(all);
+            Assert.Equal(2, all.Count());
+            Assert.Contains(all, x => x is GenericService);
+            Assert.Contains(all, x => x is AltGenericService);
         }
 
         public static IFoo FooFactory() => new Foo { Message = "expected" };

--- a/tests/Prism.Unity.Extensions.Tests/ContainerTests.cs
+++ b/tests/Prism.Unity.Extensions.Tests/ContainerTests.cs
@@ -512,7 +512,7 @@ namespace Prism.Unity.Extensions.Tests
             Assert.IsType<AltGenericService>(c.Resolve<IGenericService>());
         }
 
-        [Fact(Skip = "Not Supported on Unity")]
+        [Fact]
         public void ResolveEnumerableResolvesAll()
         {
             var c = CreateContainer();

--- a/tests/Prism.Unity.Extensions.Tests/Prism.Unity.Extensions.Tests.csproj
+++ b/tests/Prism.Unity.Extensions.Tests/Prism.Unity.Extensions.Tests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Prism.Unity.Forms.Extended.Tests/Prism.Unity.Forms.Extended.Tests.csproj
+++ b/tests/Prism.Unity.Forms.Extended.Tests/Prism.Unity.Forms.Extended.Tests.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.6.0.967" />
-    <PackageReference Include="Xamarin.Forms.Mocks" Version="4.6.0.1" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1269" />
+    <PackageReference Include="Xamarin.Forms.Mocks" Version="4.7.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Shiny.Prism.Tests/Shiny.Prism.Tests.csproj
+++ b/tests/Shiny.Prism.Tests/Shiny.Prism.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Shiny.Testing" Version="1.2.0.1755" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
# Description

This PR fixes some issues related to #124 and is a replacement to #115 

## Changes

- Fixes default DryIoc rules to allow appending
- Updates Register keyed to explicitly replace the previous registration
- Fixes Microsoft.Extensions.DependencyInject wrapper to ensure we construct unregistered concrete types as a transient.
- Adds tests for Multiple Registrations and Resolve IEnumerable<T>

## Notes

This does not solve #125. The Unity Container implementation does not currently support this behavior. 