### PR TITLE
Fix #113 Empty stack in injected INavigationService with MS DI

### DIFF
--- a/src/Prism.Microsoft.DependencyInjection.Extensions/PrismContainerExtension.cs
+++ b/src/Prism.Microsoft.DependencyInjection.Extensions/PrismContainerExtension.cs
@@ -331,6 +331,8 @@ namespace Prism.Microsoft.DependencyInjection
                 services.AddSingleton(param.Type, param.Instance);
             }
 
+            Services = services;
+
             var rootSP = services.BuildServiceProvider();
 
             if(_serviceScope is null)


### PR DESCRIPTION
Refreshing the service collection before calling BuildServiceProvider