### PR TITLE
Fix #118 Exception: Start may not be called on a continuation task

### DIFF
--- a/src/Prism.Forms.Extended/Commands/ExecutionAwareCommand{T}.cs
+++ b/src/Prism.Forms.Extended/Commands/ExecutionAwareCommand{T}.cs
@@ -76,8 +76,7 @@ namespace Prism.Commands
                         {
                             throw new UnhandledCommandException(t.Exception);
                         }
-                    })
-                        .Start();
+                    });
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
Fixing the exception when using ExecutionAwareCommand with parameter