### PR TITLE
Guard Container

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,7 +30,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" $(IsPackable) == 'true' ">
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.2.31" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" PrivateAssets="all" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
# Description

If the ContainerLocator has not yet received a delegate ContainerLocator.Current will throw a Lazy initialization exception. This will guard against that exception while checking to see the ContainerLocator has been initialized.