### PR TITLE
IServiceScope Tests / Fixes

### DIFF
--- a/tests/Prism.Container.Extensions.Shared.Tests/Tests/CommonAspNetServiceTests.cs
+++ b/tests/Prism.Container.Extensions.Shared.Tests/Tests/CommonAspNetServiceTests.cs
@@ -105,6 +105,32 @@ namespace Prism.Container.Extensions.Shared.Tests
             Assert.True(((IContainerProvider)PrismContainerExtension.Current).IsRegistered<IHttpClientFactory>());
         }
 
+        [Fact]
+        public void IServiceScopeFactoryIsRegistered()
+        {
+            PrismContainerExtension.Current.RegisterServices(s =>
+            {
+                s.AddHttpClient();
+            });
+
+            Assert.True(((IContainerProvider)PrismContainerExtension.Current).IsRegistered<IServiceScopeFactory>());
+        }
+
+        [Fact]
+        public void ResolvesHttpClientWithHttpClientFactory()
+        {
+            PrismContainerExtension.Current.RegisterServices(s =>
+            {
+                s.AddHttpClient();
+            });
+
+            HttpClient client = null;
+            var ex = Record.Exception(() => client = PrismContainerExtension.Current.Resolve<HttpClient>());
+
+            Assert.Null(ex);
+            Assert.NotNull(client);
+        }
+
         private void ConfigureServices()
         {
             var services = new ServiceCollection();


### PR DESCRIPTION
# Description

Adds tests to explicitly validate IHttpClientFactory and that IServiceScopeFactory is registered. Adds support for IServiceScopeFactory in the Microsoft.Extensions.DependencyInjection package.. not sure why this wasn't naively supported by Microsoft???