### PR TITLE
Shiny v2 updates

### DIFF
--- a/sample/PrismSample.Android/MainApplication.cs
+++ b/sample/PrismSample.Android/MainApplication.cs
@@ -20,7 +20,7 @@ namespace PrismSample.Droid
         public override void OnCreate()
         {
             base.OnCreate();
-            AndroidShinyHost.Init(this, new Startup());
+            this.ShinyOnCreate(new Startup());
         }
     }
 }

--- a/sample/PrismSample.Android/PrismSample.Android.csproj
+++ b/sample/PrismSample.Android/PrismSample.Android.csproj
@@ -53,7 +53,7 @@
     <Reference Include="System.Numerics.Vectors" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1364" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2012" />
     <PackageReference Include="Xamarin.Android.Support.Core.Utils" Version="28.0.0.3" />
   </ItemGroup>
   <ItemGroup>

--- a/sample/PrismSample.Android/PrismSample.Android.csproj
+++ b/sample/PrismSample.Android/PrismSample.Android.csproj
@@ -16,7 +16,7 @@
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
     <AndroidEnableSGenConcurrent>true</AndroidEnableSGenConcurrent>
     <AndroidUseAapt2>true</AndroidUseAapt2>
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>

--- a/sample/PrismSample.Android/Properties/AndroidManifest.xml
+++ b/sample/PrismSample.Android/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.prismlibrary.prismextensions">
-    <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="28" />
-    <application android:label="Prism Extended"></application>
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="29" />
+	<application android:label="Prism Extended"></application>
+	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>

--- a/sample/PrismSample.Android/Resources/layout/Tabbar.xml
+++ b/sample/PrismSample.Android/Resources/layout/Tabbar.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.TabLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.material.tabs.TabLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/sliding_tabs"
     android:layout_width="match_parent"

--- a/sample/PrismSample.Android/Resources/layout/Toolbar.xml
+++ b/sample/PrismSample.Android/Resources/layout/Toolbar.xml
@@ -1,4 +1,5 @@
-<android.support.v7.widget.Toolbar
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.appcompat.widget.Toolbar
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/toolbar"
     android:layout_width="match_parent"
@@ -6,4 +7,3 @@
     android:background="?attr/colorPrimary"
     android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
     android:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
-

--- a/sample/PrismSample.Android/SplashActivity.cs
+++ b/sample/PrismSample.Android/SplashActivity.cs
@@ -1,8 +1,8 @@
 ﻿using Android.App;
 using Android.OS;
-using Android.Support.V7.App;
 using Android.Content;
 using Android.Util;
+using AndroidX.AppCompat.App;
 
 namespace PrismSample.Droid
 {

--- a/sample/PrismSample.UWP/App.xaml.cs
+++ b/sample/PrismSample.UWP/App.xaml.cs
@@ -14,6 +14,8 @@ using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
+using Shiny;
+using PrismSample.Shiny;
 
 namespace PrismSample.UWP
 {
@@ -30,6 +32,7 @@ namespace PrismSample.UWP
         {
             this.InitializeComponent();
             this.Suspending += OnSuspending;
+            this.ShinyInit(new Startup());
         }
 
         /// <summary>
@@ -39,13 +42,9 @@ namespace PrismSample.UWP
         /// <param name="e">Details about the launch request and process.</param>
         protected override void OnLaunched(LaunchActivatedEventArgs e)
         {
-
-
-            Frame rootFrame = Window.Current.Content as Frame;
-
             // Do not repeat app initialization when the Window already has content,
             // just ensure that the window is active
-            if (rootFrame == null)
+            if (!(Window.Current.Content is Frame rootFrame))
             {
                 // Create a Frame to act as the navigation context and navigate to the first page
                 rootFrame = new Frame();

--- a/sample/PrismSample.UWP/PrismSample.UWP.csproj
+++ b/sample/PrismSample.UWP/PrismSample.UWP.csproj
@@ -147,6 +147,22 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.12" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Prism.Container.Extensions\Prism.Container.Extensions.csproj">
+      <Project>{940ca2d8-b9a8-499a-9ed3-ecee9758073f}</Project>
+      <Name>Prism.Container.Extensions</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Prism.DryIoc.Extensions\Prism.DryIoc.Extensions.csproj">
+      <Project>{3a82a96a-f3fc-4244-87c3-28706494f614}</Project>
+      <Name>Prism.DryIoc.Extensions</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Prism.Forms.Extended\Prism.Forms.Extended.csproj">
+      <Project>{771a0fd7-7877-4ab7-8528-7fb07054393d}</Project>
+      <Name>Prism.Forms.Extended</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Shiny.Prism\Shiny.Prism.csproj">
+      <Project>{fd30086e-fa39-408e-935f-8921b454d282}</Project>
+      <Name>Shiny.Prism</Name>
+    </ProjectReference>
     <ProjectReference Include="..\PrismSample\PrismSample.csproj">
       <Project>{0C2D6820-FA64-4050-9546-BF034329D363}</Project>
       <Name>PrismSample</Name>

--- a/sample/PrismSample.UWP/PrismSample.UWP.csproj
+++ b/sample/PrismSample.UWP/PrismSample.UWP.csproj
@@ -143,7 +143,7 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1364" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2012" />
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.12" />
   </ItemGroup>
   <ItemGroup>

--- a/sample/PrismSample.iOS/AppDelegate.cs
+++ b/sample/PrismSample.iOS/AppDelegate.cs
@@ -28,7 +28,7 @@ namespace PrismSample.iOS
         //
         public override bool FinishedLaunching(UIApplication app, NSDictionary options)
         {
-            iOSShinyHost.Init(new Startup());
+            this.ShinyFinishedLaunching(new Startup());
             global::Xamarin.Forms.Forms.Init();
             LoadApplication(new App());
 

--- a/sample/PrismSample.iOS/PrismSample.iOS.csproj
+++ b/sample/PrismSample.iOS/PrismSample.iOS.csproj
@@ -125,7 +125,7 @@
     <Reference Include="System.Numerics.Vectors" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1364" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2012" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>

--- a/sample/PrismSample/PrismSample.csproj
+++ b/sample/PrismSample/PrismSample.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Humanizer.Core" Version="2.8.26" />
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1364" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2012" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sample/PrismSample/Shiny/Startup.cs
+++ b/sample/PrismSample/Shiny/Startup.cs
@@ -1,15 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
+using Shiny;
 using Shiny.Prism;
-using Shiny.Power;
 
 namespace PrismSample.Shiny
 {
     public class Startup : PrismStartup
     {
-        protected override void ConfigureServices(IServiceCollection services)
+        protected override void ConfigureServices(IServiceCollection services, IPlatform platform)
         {
             // Register Stuff
         }

--- a/src/Prism.Container.Extensions/Prism.Container.Extensions.csproj
+++ b/src/Prism.Container.Extensions/Prism.Container.Extensions.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
     <PackageReference Include="Prism.Core" Version="8.0.0.1909" />
   </ItemGroup>
 

--- a/src/Prism.DryIoc.Extensions/Prism.DryIoc.Extensions.csproj
+++ b/src/Prism.DryIoc.Extensions/Prism.DryIoc.Extensions.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DryIoc.dll" Version="4.5.1" />
+    <PackageReference Include="DryIoc.dll" Version="4.7.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Prism.Microsoft.DependencyInjection.Extensions/Prism.Microsoft.DependencyInjection.Extensions.csproj
+++ b/src/Prism.Microsoft.DependencyInjection.Extensions/Prism.Microsoft.DependencyInjection.Extensions.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Prism.Unity.Extensions/Prism.Unity.Extensions.csproj
+++ b/src/Prism.Unity.Extensions/Prism.Unity.Extensions.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Unity.Container" Version="5.11.10" />
+    <PackageReference Include="Unity.Container" Version="5.11.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Shiny.Prism/Shiny.Prism.csproj
+++ b/src/Shiny.Prism/Shiny.Prism.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Shiny.Core" Version="2.0.0.2487-preview" />
+    <PackageReference Include="Shiny.Core" Version="2.0.0.2508-preview" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Shiny.Prism/Shiny.Prism.csproj
+++ b/src/Shiny.Prism/Shiny.Prism.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Shiny.Core" Version="1.2.0.1755" />
+    <PackageReference Include="Shiny.Core" Version="2.0.0.2487-preview" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Prism.Container.Extensions.Shared.Tests/Tests/CommonAspNetServiceTests.cs
+++ b/tests/Prism.Container.Extensions.Shared.Tests/Tests/CommonAspNetServiceTests.cs
@@ -7,6 +7,7 @@ using Prism.Container.Extensions.Shared.Mocks;
 using Xunit;
 using Prism.Ioc;
 using System.Net.Http;
+using Microsoft.Extensions.Logging;
 #if DRYIOC
 using Prism.DryIoc;
 #elif UNITY
@@ -129,6 +130,24 @@ namespace Prism.Container.Extensions.Shared.Tests
 
             Assert.Null(ex);
             Assert.NotNull(client);
+        }
+
+        [Fact]
+        public void RegistersOpenGenerics()
+        {
+            PrismContainerExtension.Current.RegisterServices(s =>
+            {
+                s.AddLogging(b => b.SetMinimumLevel(LogLevel.Warning));
+            });
+
+            ILogger<CommonAspNetServiceTests> logger = null;
+            var ex = Record.Exception(() =>
+            {
+                logger = PrismContainerExtension.Current.Resolve<ILogger<CommonAspNetServiceTests>>();
+            });
+
+            Assert.Null(ex);
+            Assert.NotNull(logger);
         }
 
         private void ConfigureServices()

--- a/tests/Prism.DryIoc.Extensions.Tests/Prism.DryIoc.Extensions.Tests.csproj
+++ b/tests/Prism.DryIoc.Extensions.Tests/Prism.DryIoc.Extensions.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/Prism.DryIoc.Extensions.Tests/Prism.DryIoc.Extensions.Tests.csproj
+++ b/tests/Prism.DryIoc.Extensions.Tests/Prism.DryIoc.Extensions.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/tests/Prism.DryIoc.Forms.Extended.Tests/Prism.DryIoc.Forms.Extended.Tests.csproj
+++ b/tests/Prism.DryIoc.Forms.Extended.Tests/Prism.DryIoc.Forms.Extended.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/tests/Prism.DryIoc.Forms.Extended.Tests/Prism.DryIoc.Forms.Extended.Tests.csproj
+++ b/tests/Prism.DryIoc.Forms.Extended.Tests/Prism.DryIoc.Forms.Extended.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1364" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2012" />
     <PackageReference Include="Xamarin.Forms.Mocks" Version="4.7.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/tests/Prism.Microsoft.DependencyInjection.Extensions.Forms.Tests/Prism.Microsoft.DependencyInjection.Forms.Extended.Tests.csproj
+++ b/tests/Prism.Microsoft.DependencyInjection.Extensions.Forms.Tests/Prism.Microsoft.DependencyInjection.Forms.Extended.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/tests/Prism.Microsoft.DependencyInjection.Extensions.Forms.Tests/Prism.Microsoft.DependencyInjection.Forms.Extended.Tests.csproj
+++ b/tests/Prism.Microsoft.DependencyInjection.Extensions.Forms.Tests/Prism.Microsoft.DependencyInjection.Forms.Extended.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1364" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2012" />
     <PackageReference Include="Xamarin.Forms.Mocks" Version="4.7.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/tests/Prism.Microsoft.DependencyInjection.Extensions.Tests/Prism.Microsoft.DependencyInjection.Extensions.Tests.csproj
+++ b/tests/Prism.Microsoft.DependencyInjection.Extensions.Tests/Prism.Microsoft.DependencyInjection.Extensions.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/tests/Prism.Microsoft.DependencyInjection.Extensions.Tests/Prism.Microsoft.DependencyInjection.Extensions.Tests.csproj
+++ b/tests/Prism.Microsoft.DependencyInjection.Extensions.Tests/Prism.Microsoft.DependencyInjection.Extensions.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/Prism.Unity.Extensions.Tests/Prism.Unity.Extensions.Tests.csproj
+++ b/tests/Prism.Unity.Extensions.Tests/Prism.Unity.Extensions.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/Prism.Unity.Extensions.Tests/Prism.Unity.Extensions.Tests.csproj
+++ b/tests/Prism.Unity.Extensions.Tests/Prism.Unity.Extensions.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/tests/Prism.Unity.Forms.Extended.Tests/Prism.Unity.Forms.Extended.Tests.csproj
+++ b/tests/Prism.Unity.Forms.Extended.Tests/Prism.Unity.Forms.Extended.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1364" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2012" />
     <PackageReference Include="Xamarin.Forms.Mocks" Version="4.7.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/Prism.Unity.Forms.Extended.Tests/Prism.Unity.Forms.Extended.Tests.csproj
+++ b/tests/Prism.Unity.Forms.Extended.Tests/Prism.Unity.Forms.Extended.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/tests/Shiny.Prism.Tests/Mocks/MockStartup.cs
+++ b/tests/Shiny.Prism.Tests/Mocks/MockStartup.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/tests/Shiny.Prism.Tests/Mocks/ShinyPrismTestHost.cs
+++ b/tests/Shiny.Prism.Tests/Mocks/ShinyPrismTestHost.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Reactive.Subjects;
 using System.Text;
 using Microsoft.Extensions.DependencyInjection;
-using Shiny.IO;
 using Shiny.Jobs;
 using Shiny.Net;
 using Shiny.Power;
@@ -16,22 +17,49 @@ using Xunit.Abstractions;
 
 namespace Shiny.Prism.Mocks
 {
-    class ShinyPrismTestHost : ShinyHost
+    class ShinyPrismTestHost : IPlatform
     {
+        private readonly Subject<PlatformState> _stateChanged = new Subject<PlatformState>();
+        private readonly Action<IServiceCollection> _platformBuild;
+
+        private ShinyPrismTestHost(Action<IServiceCollection> platformBuild)
+        {
+            _platformBuild = platformBuild;
+        }
+
+        public DirectoryInfo AppData { get; }
+        public DirectoryInfo Cache { get; }
+        public DirectoryInfo Public { get; }
+        public string AppIdentifier { get; }
+        public string AppVersion { get; }
+        public string AppBuild { get; }
+        public string MachineName { get; }
+        public string OperatingSystem { get; }
+        public string OperatingSystemVersion { get; }
+        public string Manufacturer { get; }
+        public string Model { get; }
+
         public static void Init(ITestOutputHelper testOutputHelper) => Init(new MockStartup(testOutputHelper));
 
         public static void Init(IShinyStartup startup = null, Action<IServiceCollection> platformBuild = null)
         {
-            InitPlatform(startup, services =>
-            {
-                services.AddSingleton<IJobManager, TestJobManager>();
-                services.AddSingleton<IConnectivity, TestConnectivity>();
-                services.AddSingleton<IPowerManager, TestPowerManager>();
-                services.AddSingleton<IFileSystem, FileSystemImpl>();
-                services.AddSingleton<ISettings, TestSettings>();
-                services.AddSingleton<IEnvironment, TestEnvironment>();
-                platformBuild?.Invoke(services);
-            });
+            ShinyHost.Init(new ShinyPrismTestHost(platformBuild), startup);
+        }
+
+        public void Register(IServiceCollection services)
+        {
+            services.AddSingleton<IJobManager, TestJobManager>();
+            services.AddSingleton<IConnectivity, TestConnectivity>();
+            services.AddSingleton<IPowerManager, TestPowerManager>();
+            //services.AddSingleton<IFileSystem, FileSystemImpl>();
+            services.AddSingleton<ISettings, TestSettings>();
+            //services.AddSingleton<IEnvironment, TestEnvironment>();
+            _platformBuild?.Invoke(services);
+        }
+
+        public IObservable<PlatformState> WhenStateChanged()
+        {
+            return _stateChanged;
         }
     }
 }

--- a/tests/Shiny.Prism.Tests/Mocks/ShinyPrismTestHost.cs
+++ b/tests/Shiny.Prism.Tests/Mocks/ShinyPrismTestHost.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Reactive.Subjects;
-using System.Text;
 using Microsoft.Extensions.DependencyInjection;
+using Shiny.Infrastructure;
 using Shiny.Jobs;
 using Shiny.Net;
 using Shiny.Power;
@@ -17,27 +15,14 @@ using Xunit.Abstractions;
 
 namespace Shiny.Prism.Mocks
 {
-    class ShinyPrismTestHost : IPlatform
+    class ShinyPrismTestHost : TestPlatform
     {
-        private readonly Subject<PlatformState> _stateChanged = new Subject<PlatformState>();
         private readonly Action<IServiceCollection> _platformBuild;
 
         private ShinyPrismTestHost(Action<IServiceCollection> platformBuild)
         {
             _platformBuild = platformBuild;
         }
-
-        public DirectoryInfo AppData { get; }
-        public DirectoryInfo Cache { get; }
-        public DirectoryInfo Public { get; }
-        public string AppIdentifier { get; }
-        public string AppVersion { get; }
-        public string AppBuild { get; }
-        public string MachineName { get; }
-        public string OperatingSystem { get; }
-        public string OperatingSystemVersion { get; }
-        public string Manufacturer { get; }
-        public string Model { get; }
 
         public static void Init(ITestOutputHelper testOutputHelper) => Init(new MockStartup(testOutputHelper));
 
@@ -46,20 +31,15 @@ namespace Shiny.Prism.Mocks
             ShinyHost.Init(new ShinyPrismTestHost(platformBuild), startup);
         }
 
-        public void Register(IServiceCollection services)
+        public override void Register(IServiceCollection services)
         {
+            base.Register(services);
             services.AddSingleton<IJobManager, TestJobManager>();
             services.AddSingleton<IConnectivity, TestConnectivity>();
             services.AddSingleton<IPowerManager, TestPowerManager>();
-            //services.AddSingleton<IFileSystem, FileSystemImpl>();
             services.AddSingleton<ISettings, TestSettings>();
-            //services.AddSingleton<IEnvironment, TestEnvironment>();
+            services.AddSingleton<ISerializer, ShinySerializer>();
             _platformBuild?.Invoke(services);
-        }
-
-        public IObservable<PlatformState> WhenStateChanged()
-        {
-            return _stateChanged;
         }
     }
 }

--- a/tests/Shiny.Prism.Tests/Shiny.Prism.Tests.csproj
+++ b/tests/Shiny.Prism.Tests/Shiny.Prism.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="Shiny.Testing" Version="1.2.0.1755" />
+    <PackageReference Include="Shiny.Testing" Version="2.0.0.2487-preview" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Shiny.Prism.Tests/Shiny.Prism.Tests.csproj
+++ b/tests/Shiny.Prism.Tests/Shiny.Prism.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/tests/Shiny.Prism.Tests/Shiny.Prism.Tests.csproj
+++ b/tests/Shiny.Prism.Tests/Shiny.Prism.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="Shiny.Testing" Version="2.0.0.2487-preview" />
+    <PackageReference Include="Shiny.Testing" Version="2.0.0.2508-preview" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Shiny.Prism.Tests/Tests/PrismStartupTests.cs
+++ b/tests/Shiny.Prism.Tests/Tests/PrismStartupTests.cs
@@ -1,13 +1,11 @@
 using System;
 using Prism.DryIoc;
 using Prism.Ioc;
-using Shiny.IO;
 using Shiny.Jobs;
 using Shiny.Net;
 using Shiny.Power;
 using Shiny.Prism.Mocks;
 using Shiny.Settings;
-using Shiny.Testing;
 using Shiny.Testing.Jobs;
 using Shiny.Testing.Net;
 using Shiny.Testing.Power;
@@ -39,10 +37,7 @@ namespace Shiny.Prism.Tests
         [InlineData(typeof(IJobManager), typeof(TestJobManager))]
         [InlineData(typeof(IConnectivity), typeof(TestConnectivity))]
         [InlineData(typeof(IPowerManager), typeof(TestPowerManager))]
-        [InlineData(typeof(IFileSystem), typeof(FileSystemImpl))]
         [InlineData(typeof(ISettings), typeof(TestSettings))]
-        [InlineData(typeof(IEnvironment), typeof(TestEnvironment))]
-        //[InlineData(typeof(IBleAdapterDelegate), typeof(MockBleAdapterDelegate))]
         public void ExpectedTypesAreRegisteredAndResolve(Type serviceType, Type implementingType)
         {
             ShinyPrismTestHost.Init(_testOutputHelper);

--- a/tests/Shiny.Prism.Tests/Tests/PrismStartupTests.cs
+++ b/tests/Shiny.Prism.Tests/Tests/PrismStartupTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Prism.DryIoc;
 using Prism.Ioc;
 using Shiny.Jobs;
@@ -34,6 +35,7 @@ namespace Shiny.Prism.Tests
         }
 
         [Theory]
+        [InlineData(typeof(IPlatform), typeof(ShinyPrismTestHost))]
         [InlineData(typeof(IJobManager), typeof(TestJobManager))]
         [InlineData(typeof(IConnectivity), typeof(TestConnectivity))]
         [InlineData(typeof(IPowerManager), typeof(TestPowerManager))]
@@ -41,6 +43,13 @@ namespace Shiny.Prism.Tests
         public void ExpectedTypesAreRegisteredAndResolve(Type serviceType, Type implementingType)
         {
             ShinyPrismTestHost.Init(_testOutputHelper);
+            var types = ContainerLocator.Container
+                .GetContainer()
+                .GetServiceRegistrations()
+                .Where(x => x.ServiceType.Assembly.GetName().Name == "Shiny.Core");
+            foreach (var type in types)
+                _testOutputHelper.WriteLine($"Found: {type.ServiceType.FullName} - {type.ImplementationType?.FullName}");
+
             Assert.True(PrismContainerExtension.Current.IsRegistered(serviceType));
 
             var fromShiny = ShinyHost.Container.GetService(serviceType);
@@ -54,7 +63,7 @@ namespace Shiny.Prism.Tests
             var ex = Record.Exception(() => ShinyPrismTestHost.Init(new MockStartup(_testOutputHelper, false)));
 
             Assert.Null(ex);
-            Assert.NotNull(PrismContainerExtension.Current.Resolve<IConnectivity>());
+            Assert.NotNull(PrismContainerExtension.Current.Resolve<IJobManager>());
         }
     }
 }


### PR DESCRIPTION
# Description

A recent v2 update to Shiny removed support for the Shiny ILogger. During that update the API for IShinyStartup was changed making Shiny v2 binary incompatible with Shiny.Prism. 

- fixes #183